### PR TITLE
Deprecations

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -105,8 +105,8 @@ flags = ['-funsigned-char',
          '-Werror=date-time',
          '-Wno-conversion',
          '-Wno-sign-compare',
-         '-Wno-deprecated-declarations',
-         '-Wno-deprecated',
+         '-Wdeprecated-declarations',
+         '-Wdeprecated',
          '-Wno-error=format-nonliteral']
 
 cflags = cc.get_supported_arguments(flags)

--- a/src/hig.c
+++ b/src/hig.c
@@ -53,7 +53,8 @@ hig_workarea_add_section_title (GtkWidget *  t, guint * row, const char * sectio
 
     g_snprintf (buf, sizeof (buf), "<b>%s</b>", section_title);
     l = gtk_label_new (buf);
-    gtk_misc_set_alignment (GTK_MISC (l), 0.0f, 0.5f);
+    gtk_label_set_xalign (GTK_LABEL (l), 0.0f);
+    gtk_label_set_yalign (GTK_LABEL (l), 0.5f);
     gtk_label_set_use_markup (GTK_LABEL (l), TRUE);
     hig_workarea_add_section_title_widget (t, row, l);
 }
@@ -91,19 +92,22 @@ void
 hig_workarea_add_label_w (GtkWidget * t, guint row, GtkWidget * w)
 {
     gtk_widget_set_margin_left (w, 18);
-    if (GTK_IS_MISC (w))
-        gtk_misc_set_alignment (GTK_MISC (w), 0.0f, 0.5f);
-    if (GTK_IS_LABEL (w))
+    if (GTK_IS_LABEL (w)) {
         gtk_label_set_use_markup (GTK_LABEL (w), TRUE);
+        gtk_label_set_xalign(GTK_LABEL (w), 0.0f);
+        gtk_label_set_yalign(GTK_LABEL (w), 0.5f);
+    }
     gtk_grid_attach (GTK_GRID (t), w, 0, row, 1, 1);
 }
 
 static void
 hig_workarea_add_tall_control (GtkWidget * t, guint row, GtkWidget * control)
 {
-    if (GTK_IS_MISC (control))
-        gtk_misc_set_alignment (GTK_MISC (control), 0.0f, 0.5f);
+    if (GTK_IS_LABEL (control)) {
 
+        gtk_label_set_xalign (GTK_LABEL (control), 0.0f);
+        gtk_label_set_yalign (GTK_LABEL (control), 0.5f);
+    }
     g_object_set (control, "expand", TRUE, NULL);
     gtk_grid_attach (GTK_GRID (t), control, 1, row, 1, 1);
 }
@@ -111,9 +115,10 @@ hig_workarea_add_tall_control (GtkWidget * t, guint row, GtkWidget * control)
 static void
 hig_workarea_add_control (GtkWidget * t, guint row, GtkWidget * control)
 {
-    if (GTK_IS_MISC (control))
-        gtk_misc_set_alignment (GTK_MISC (control), 0.0f, 0.5f);
-
+    if (GTK_IS_LABEL (control)) {
+        gtk_label_set_xalign (GTK_LABEL (control), 0.0f);
+        gtk_label_set_yalign (GTK_LABEL (control), 0.5f);
+    }
     gtk_widget_set_hexpand (control, TRUE);
     gtk_grid_attach (GTK_GRID (t), control, 1, row, 1, 1);
 }

--- a/src/hig.c
+++ b/src/hig.c
@@ -28,16 +28,6 @@ hig_workarea_create (void)
 }
 
 void
-hig_workarea_add_section_divider (GtkWidget * t, guint * row)
-{
-    GtkWidget * w = gtk_alignment_new (0.0f, 0.0f, 0.0f, 0.0f);
-
-    gtk_widget_set_size_request (w, 0u, 6u);
-    gtk_grid_attach (GTK_GRID (t), w, 0, *row, 2, 1);
-    ++ * row;
-}
-
-void
 hig_workarea_add_section_title_widget (GtkWidget * t, guint * row, GtkWidget * w)
 {
     gtk_widget_set_hexpand (w, TRUE);

--- a/src/hig.c
+++ b/src/hig.c
@@ -63,7 +63,7 @@ void
 hig_workarea_add_wide_control (GtkWidget * t, guint * row, GtkWidget * w)
 {
     gtk_widget_set_hexpand (w, TRUE);
-    gtk_widget_set_margin_left (w, 18);
+    gtk_widget_set_margin_start (w, 18);
     gtk_grid_attach (GTK_GRID (t), w, 0, *row, 2, 1);
     ++ * row;
 }
@@ -91,7 +91,7 @@ hig_workarea_add_wide_checkbutton (GtkWidget  * t,
 void
 hig_workarea_add_label_w (GtkWidget * t, guint row, GtkWidget * w)
 {
-    gtk_widget_set_margin_left (w, 18);
+    gtk_widget_set_margin_start (w, 18);
     if (GTK_IS_LABEL (w)) {
         gtk_label_set_use_markup (GTK_LABEL (w), TRUE);
         gtk_label_set_xalign(GTK_LABEL (w), 0.0f);

--- a/src/hig.h
+++ b/src/hig.h
@@ -22,9 +22,6 @@
 
 GtkWidget* hig_workarea_create (void);
 
-void       hig_workarea_add_section_divider (GtkWidget * table,
-                                             guint     *  row);
-
 void       hig_workarea_add_section_title_widget (GtkWidget * t,
                                                   guint     * row,
                                                   GtkWidget * w);

--- a/src/icons.c
+++ b/src/icons.c
@@ -51,12 +51,11 @@ static GdkPixbuf *create_void_pixbuf(int width, int height)
 }
 
 
-static int get_size_in_pixels(GtkWidget * widget, GtkIconSize icon_size)
+static int get_size_in_pixels(GtkIconSize icon_size)
 {
     int width, height;
 
-    gtk_icon_size_lookup_for_settings(gtk_widget_get_settings(widget),
-                                      icon_size, &width, &height);
+    gtk_icon_size_lookup(icon_size, &width, &height);
     return MAX(width, height);
 }
 
@@ -70,7 +69,7 @@ static IconCache *icon_cache_new(GtkWidget * for_widget, int icon_size)
     icon_cache = g_new0(IconCache, 1);
     icon_cache->icon_theme =
         gtk_icon_theme_get_for_screen(gtk_widget_get_screen(for_widget));
-    icon_cache->icon_size = get_size_in_pixels(for_widget, icon_size);
+    icon_cache->icon_size = get_size_in_pixels(icon_size);
     icon_cache->cache =
         g_hash_table_new_full(g_str_hash, g_str_equal, NULL,
                               g_object_unref);
@@ -140,7 +139,7 @@ static GdkPixbuf *get_themed_icon_pixbuf(GThemedIcon * icon,
         g_clear_error(&error);
     }
 
-    gtk_icon_info_free(icon_info);
+    g_clear_object(&icon_info);
     g_strfreev(icon_names);
 
     return pixbuf;

--- a/src/trg-file-rename-dialog.c
+++ b/src/trg-file-rename-dialog.c
@@ -181,11 +181,7 @@ static GObject *trg_file_rename_dialog_constructor(GType type,
 
     gtk_dialog_set_default_response(GTK_DIALOG(object),
                                     GTK_RESPONSE_ACCEPT);
-
-    gtk_dialog_set_alternative_button_order(GTK_DIALOG(object),
-                                            GTK_RESPONSE_ACCEPT,
-                                            GTK_RESPONSE_CANCEL, -1);
-
+ 
     gtk_container_set_border_width(GTK_CONTAINER(t), GUI_PAD);
 
     gtk_box_pack_start(GTK_BOX

--- a/src/trg-files-model.c
+++ b/src/trg-files-model.c
@@ -458,8 +458,7 @@ trg_files_model_update(TrgFilesModel * model, GtkTreeView * tv,
          * for. Just do it in the main loop.
          */
         if (futd->idle_add) {
-            g_thread_create(trg_files_model_buildtree_threadfunc, futd,
-                            FALSE, NULL);
+            g_thread_new(NULL, trg_files_model_buildtree_threadfunc, futd);
         } else {
             trg_files_model_buildtree_threadfunc(futd);
             trg_files_model_applytree_idlefunc(futd);

--- a/src/trg-general-panel.c
+++ b/src/trg-general-panel.c
@@ -31,12 +31,9 @@
 #include "trg-torrent-model.h"
 #include "protocol-constants.h"
 
-#define TRG_GENERAL_PANEL_WIDTH_FROM_KEY    20
-#define TRG_GENERAL_PANEL_WIDTH_FROM_VALUE  60
 #define TRG_GENERAL_PANEL_SPACING_X         4
 #define TRG_GENERAL_PANEL_SPACING_Y         2
-#define TRG_GENERAL_PANEL_COLUMNS           3
-#define TRG_GENERAL_PANEL_COLUMNS_TOTAL     (TRG_GENERAL_PANEL_COLUMNS*2)
+#define TRG_GENERAL_PANEL_COLUMNS           6
 
 static void gtk_label_clear(GtkLabel * l);
 static GtkLabel *gen_panel_label_get_key_label(GtkLabel * l);
@@ -44,7 +41,7 @@ static GtkLabel *trg_general_panel_add_label(TrgGeneralPanel * gp,
                                              char *key, guint col,
                                              guint row);
 
-G_DEFINE_TYPE(TrgGeneralPanel, trg_general_panel, GTK_TYPE_TABLE)
+G_DEFINE_TYPE(TrgGeneralPanel, trg_general_panel, GTK_TYPE_GRID)
 #define TRG_GENERAL_PANEL_GET_PRIVATE(o) \
   (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_GENERAL_PANEL, TrgGeneralPanelPrivate))
 typedef struct _TrgGeneralPanelPrivate TrgGeneralPanelPrivate;
@@ -268,11 +265,15 @@ static GtkLabel *trg_general_panel_add_label_with_width(TrgGeneralPanel *
 {
     GtkWidget *value, *keyLabel;
 
-    int startCol = col * 2;
+    guint startCol = col * 2;
+    guint endCol = (guint)(width < 0
+                           ? (TRG_GENERAL_PANEL_COLUMNS)
+                           : width);
 
     keyLabel = gtk_label_new(NULL);
     gtk_label_set_xalign(GTK_LABEL(keyLabel), 0.0f);
     gtk_label_set_yalign(GTK_LABEL(keyLabel), 0.0f);
+    gtk_label_set_width_chars(GTK_LABEL(keyLabel), 10);
 
     if (strlen(key) > 0) {
         gchar *keyMarkup =
@@ -281,22 +282,20 @@ static GtkLabel *trg_general_panel_add_label_with_width(TrgGeneralPanel *
         gtk_label_set_markup(GTK_LABEL(keyLabel), keyMarkup);
         g_free(keyMarkup);
     }
-    gtk_table_attach(GTK_TABLE(gp), keyLabel, startCol, startCol + 1, row,
-                     row + 1, GTK_FILL, 0, TRG_GENERAL_PANEL_SPACING_X,
-                     TRG_GENERAL_PANEL_SPACING_Y);
+    gtk_grid_attach(GTK_GRID(gp), keyLabel,
+                    startCol, row,
+                    1, 1);
 
     value = gtk_label_new(NULL);
     gtk_label_set_xalign(GTK_LABEL(value), 0.0f);
     gtk_label_set_yalign(GTK_LABEL(value), 0.0f);
+    gtk_label_set_width_chars(GTK_LABEL(value), 10);
 
     g_object_set_data(G_OBJECT(value), "key-label", keyLabel);
     gtk_label_set_selectable(GTK_LABEL(value), TRUE);
-    gtk_table_attach(GTK_TABLE(gp), value, startCol + 1,
-                     width <
-                     0 ? TRG_GENERAL_PANEL_COLUMNS_TOTAL - 1 : startCol +
-                     1 + width, row, row + 1, GTK_FILL | GTK_SHRINK, 0,
-                     TRG_GENERAL_PANEL_SPACING_X,
-                     TRG_GENERAL_PANEL_SPACING_Y);
+    gtk_grid_attach(GTK_GRID(gp), value,
+                    startCol + 1, row,
+                    endCol, 1);
 
     return GTK_LABEL(value);
 }
@@ -311,11 +310,6 @@ static GtkLabel *trg_general_panel_add_label(TrgGeneralPanel * gp,
 static void trg_general_panel_init(TrgGeneralPanel * self)
 {
     TrgGeneralPanelPrivate *priv = TRG_GENERAL_PANEL_GET_PRIVATE(self);
-    int i;
-
-    g_object_set(G_OBJECT(self), "n-columns",
-                 TRG_GENERAL_PANEL_COLUMNS_TOTAL, "n-rows", 8, NULL);
-
 	priv->gen_name_label =
 		trg_general_panel_add_label_with_width(self, _("Name"), 0, 0, -1);
 
@@ -366,12 +360,9 @@ static void trg_general_panel_init(TrgGeneralPanel * self)
 	priv->gen_error_label =
 		trg_general_panel_add_label_with_width(self, "", 0, 9, -1);
 
-    for (i = 0; i < TRG_GENERAL_PANEL_COLUMNS_TOTAL; i++)
-        gtk_table_set_col_spacing(GTK_TABLE(self), i,
-                                  i % 2 ==
-                                  0 ? TRG_GENERAL_PANEL_WIDTH_FROM_KEY :
-                                  TRG_GENERAL_PANEL_WIDTH_FROM_VALUE);
-
+    gtk_grid_set_row_homogeneous(GTK_GRID(self), TRUE);
+    gtk_grid_set_column_spacing(GTK_GRID(self), TRG_GENERAL_PANEL_SPACING_X);
+    gtk_grid_set_row_spacing(GTK_GRID(self), TRG_GENERAL_PANEL_SPACING_Y);
     gtk_widget_set_sensitive(GTK_WIDGET(self), FALSE);
 }
 

--- a/src/trg-general-panel.c
+++ b/src/trg-general-panel.c
@@ -266,12 +266,14 @@ static GtkLabel *trg_general_panel_add_label_with_width(TrgGeneralPanel *
                                                         guint row,
                                                         gint width)
 {
-    GtkWidget *value, *keyLabel, *alignment;
+    GtkWidget *value, *keyLabel;
 
     int startCol = col * 2;
 
-    alignment = gtk_alignment_new(0, 0, 0, 0);
     keyLabel = gtk_label_new(NULL);
+    gtk_label_set_xalign(GTK_LABEL(keyLabel), 0.0f);
+    gtk_label_set_yalign(GTK_LABEL(keyLabel), 0.0f);
+
     if (strlen(key) > 0) {
         gchar *keyMarkup =
             g_markup_printf_escaped(strlen(key) > 0 ? "<b>%s:</b>" : "",
@@ -279,17 +281,17 @@ static GtkLabel *trg_general_panel_add_label_with_width(TrgGeneralPanel *
         gtk_label_set_markup(GTK_LABEL(keyLabel), keyMarkup);
         g_free(keyMarkup);
     }
-    gtk_container_add(GTK_CONTAINER(alignment), keyLabel);
-    gtk_table_attach(GTK_TABLE(gp), alignment, startCol, startCol + 1, row,
+    gtk_table_attach(GTK_TABLE(gp), keyLabel, startCol, startCol + 1, row,
                      row + 1, GTK_FILL, 0, TRG_GENERAL_PANEL_SPACING_X,
                      TRG_GENERAL_PANEL_SPACING_Y);
 
-    alignment = gtk_alignment_new(0, 0, 0, 0);
     value = gtk_label_new(NULL);
+    gtk_label_set_xalign(GTK_LABEL(value), 0.0f);
+    gtk_label_set_yalign(GTK_LABEL(value), 0.0f);
+
     g_object_set_data(G_OBJECT(value), "key-label", keyLabel);
     gtk_label_set_selectable(GTK_LABEL(value), TRUE);
-    gtk_container_add(GTK_CONTAINER(alignment), value);
-    gtk_table_attach(GTK_TABLE(gp), alignment, startCol + 1,
+    gtk_table_attach(GTK_TABLE(gp), value, startCol + 1,
                      width <
                      0 ? TRG_GENERAL_PANEL_COLUMNS_TOTAL - 1 : startCol +
                      1 + width, row, row + 1, GTK_FILL | GTK_SHRINK, 0,

--- a/src/trg-general-panel.h
+++ b/src/trg-general-panel.h
@@ -41,11 +41,11 @@ G_BEGIN_DECLS
 #define TRG_GENERAL_PANEL_GET_CLASS(obj) \
   (G_TYPE_INSTANCE_GET_CLASS ((obj), TRG_TYPE_GENERAL_PANEL, TrgGeneralPanelClass))
     typedef struct {
-    GtkTable parent;
+    GtkGrid parent;
 } TrgGeneralPanel;
 
 typedef struct {
-    GtkTableClass parent_class;
+    GtkGridClass parent_class;
 } TrgGeneralPanelClass;
 
 GType trg_general_panel_get_type(void);

--- a/src/trg-main-window.c
+++ b/src/trg-main-window.c
@@ -842,9 +842,6 @@ confirm_action_dialog(GtkWindow * gtk_win,
                            GTK_RESPONSE_ACCEPT, NULL);
     gtk_dialog_set_default_response(GTK_DIALOG(dialog),
                                     GTK_RESPONSE_CANCEL);
-    gtk_dialog_set_alternative_button_order(GTK_DIALOG(dialog),
-                                            GTK_RESPONSE_ACCEPT,
-                                            GTK_RESPONSE_CANCEL, -1);
 
     response = gtk_dialog_run(GTK_DIALOG(dialog));
     gtk_widget_destroy(dialog);

--- a/src/trg-main-window.c
+++ b/src/trg-main-window.c
@@ -2616,12 +2616,6 @@ static GObject *trg_main_window_constructor(GType type,
 
     outerVbox = trg_vbox_new(FALSE, 0);
 
-    /* Create a GtkAlignment to hold the outerVbox making possible
-     * some padding. */
-    //outerAlignment = gtk_alignment_new (0.5f, 0.5f, 1.0f, 1.0f);
-    //gtk_alignment_set_padding (GTK_ALIGNMENT (outerAlignment), 0, 0, 0, 0);
-    //gtk_container_add (GTK_CONTAINER (outerAlignment), outerVbox);
-
     gtk_container_add(GTK_CONTAINER(self), outerVbox);
 
     priv->menuBar = trg_main_window_menu_bar_new(self);

--- a/src/trg-main-window.c
+++ b/src/trg-main-window.c
@@ -995,9 +995,8 @@ static GtkWidget *trg_main_window_notebook_new(TrgMainWindow * win)
     gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(genScrolledWin),
                                    GTK_POLICY_AUTOMATIC,
                                    GTK_POLICY_AUTOMATIC);
-    gtk_scrolled_window_add_with_viewport(GTK_SCROLLED_WINDOW
-                                          (genScrolledWin),
-                                          GTK_WIDGET(priv->genDetails));
+    gtk_container_add(GTK_CONTAINER(genScrolledWin),
+                      GTK_WIDGET(priv->genDetails));
     gtk_notebook_append_page(GTK_NOTEBOOK(notebook), genScrolledWin,
                              gtk_label_new(_("General")));
 

--- a/src/trg-persistent-tree-view.c
+++ b/src/trg-persistent-tree-view.c
@@ -33,7 +33,7 @@
  */
 
 G_DEFINE_TYPE(TrgPersistentTreeView, trg_persistent_tree_view,
-              GTK_TYPE_VBOX)
+              GTK_TYPE_BOX)
 #define GET_PRIVATE(o) \
   (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_PERSISTENT_TREE_VIEW, TrgPersistentTreeViewPrivate))
 typedef struct _TrgPersistentTreeViewPrivate
@@ -510,6 +510,7 @@ TrgPersistentTreeView *trg_persistent_tree_view_new(TrgPrefs * prefs,
         g_object_new(TRG_TYPE_PERSISTENT_TREE_VIEW, "prefs", prefs,
                      "conf-key", key, "persistent-model",
                      model, "conf-flags", conf_flags,
+                     "orientation", GTK_ORIENTATION_VERTICAL,
                      NULL);
 
     return TRG_PERSISTENT_TREE_VIEW(obj);

--- a/src/trg-status-bar.c
+++ b/src/trg-status-bar.c
@@ -43,7 +43,7 @@
  * main window, which calls this. Session updates happen every 10 torrent-get updates.
  */
 
-G_DEFINE_TYPE(TrgStatusBar, trg_status_bar, GTK_TYPE_HBOX)
+G_DEFINE_TYPE(TrgStatusBar, trg_status_bar, GTK_TYPE_BOX)
 #define TRG_STATUS_BAR_GET_PRIVATE(o) \
   (G_TYPE_INSTANCE_GET_PRIVATE ((o), TRG_TYPE_STATUS_BAR, TrgStatusBarPrivate))
 typedef struct _TrgStatusBarPrivate TrgStatusBarPrivate;
@@ -260,7 +260,10 @@ const gchar *trg_status_bar_get_speed_text(TrgStatusBar * s)
 
 TrgStatusBar *trg_status_bar_new(TrgMainWindow * win, TrgClient * client)
 {
-    TrgStatusBar *sb = g_object_new(TRG_TYPE_STATUS_BAR, NULL);
+    TrgStatusBar *sb = g_object_new(TRG_TYPE_STATUS_BAR,
+                                    "orientation",
+                                    GTK_ORIENTATION_HORIZONTAL,
+                                    NULL);
     TrgStatusBarPrivate *priv = TRG_STATUS_BAR_GET_PRIVATE(sb);
 
     priv->client = client;

--- a/src/trg-torrent-add-dialog.c
+++ b/src/trg-torrent-add-dialog.c
@@ -574,9 +574,6 @@ static GtkWidget *trg_torrent_add_dialog_generic(GtkWindow * parent,
     }
 
     addTorrentFilters(GTK_FILE_CHOOSER(w));
-    gtk_dialog_set_alternative_button_order(GTK_DIALOG(w),
-                                            GTK_RESPONSE_ACCEPT,
-                                            GTK_RESPONSE_CANCEL, -1);
     gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(w), TRUE);
     return w;
 }
@@ -713,9 +710,6 @@ static GObject *trg_torrent_add_dialog_constructor(GType type,
                           GTK_RESPONSE_CANCEL);
     gtk_dialog_add_button(GTK_DIALOG(obj), _("_Open"),
                           GTK_RESPONSE_ACCEPT);
-    gtk_dialog_set_alternative_button_order(GTK_DIALOG(obj),
-                                            GTK_RESPONSE_ACCEPT,
-                                            GTK_RESPONSE_CANCEL, -1);
     gtk_dialog_set_default_response(GTK_DIALOG(obj), GTK_RESPONSE_ACCEPT);
     gtk_widget_grab_focus(gtk_dialog_get_widget_for_response (GTK_DIALOG(obj),
 							      GTK_RESPONSE_ACCEPT));

--- a/src/trg-torrent-add-dialog.c
+++ b/src/trg-torrent-add-dialog.c
@@ -740,9 +740,7 @@ static GObject *trg_torrent_add_dialog_constructor(GType type,
 
     priv->source_chooser = gtk_button_new();
     hig_workarea_add_row(t, &row, _("_Torrent file:"), priv->source_chooser, NULL);
-
-    gtk_button_set_alignment(GTK_BUTTON(priv->source_chooser), 0.0f, 0.5f);
-
+ 
     if (priv->filenames)
 		trg_torrent_add_dialog_set_filenames(TRG_TORRENT_ADD_DIALOG(obj),
 											 priv->filenames);

--- a/src/trg-torrent-add-url-dialog.c
+++ b/src/trg-torrent-add-url-dialog.c
@@ -146,10 +146,6 @@ static void trg_torrent_add_url_dialog_init(TrgTorrentAddUrlDialog * self)
 
     gtk_dialog_set_default_response(GTK_DIALOG(self), GTK_RESPONSE_ACCEPT);
 
-    gtk_dialog_set_alternative_button_order(GTK_DIALOG(self),
-                                            GTK_RESPONSE_ACCEPT,
-                                            GTK_RESPONSE_CANCEL, -1);
-
     gtk_container_set_border_width(GTK_CONTAINER(t), GUI_PAD);
 
     gtk_box_pack_start(GTK_BOX(contentvbox), t, TRUE, TRUE, 0);

--- a/src/trg-torrent-move-dialog.c
+++ b/src/trg-torrent-move-dialog.c
@@ -137,10 +137,6 @@ static GObject *trg_torrent_move_dialog_constructor(GType type,
     gtk_dialog_set_default_response(GTK_DIALOG(object),
                                     GTK_RESPONSE_ACCEPT);
 
-    gtk_dialog_set_alternative_button_order(GTK_DIALOG(object),
-                                            GTK_RESPONSE_ACCEPT,
-                                            GTK_RESPONSE_CANCEL, -1);
-
     gtk_container_set_border_width(GTK_CONTAINER(t), GUI_PAD);
 
     gtk_box_pack_start(GTK_BOX

--- a/src/trg-torrent-props-dialog.c
+++ b/src/trg-torrent-props-dialog.c
@@ -285,7 +285,8 @@ static GtkWidget *info_page_new(TrgTorrentPropsDialog * dialog)
     gtk_frame_set_shadow_type(GTK_FRAME(fr), GTK_SHADOW_IN);
     gtk_container_add(GTK_CONTAINER(fr), sw);
     w = hig_workarea_add_tall_row(t, &row, _("Comment:"), fr, NULL);
-    gtk_misc_set_alignment(GTK_MISC(w), 0.0f, 0.0f);
+    gtk_widget_set_halign(w, GTK_ALIGN_START);
+    gtk_widget_set_valign(w, GTK_ALIGN_START);
 
     hig_workarea_add_section_divider(t, &row);
     return t;

--- a/src/trg-torrent-props-dialog.c
+++ b/src/trg-torrent-props-dialog.c
@@ -243,7 +243,6 @@ static GtkWidget *info_page_new(TrgTorrentPropsDialog * dialog)
     hig_workarea_add_row(t, &row, _("Error:"), l, NULL);
     priv->error_lb = l;
 
-    hig_workarea_add_section_divider(t, &row);
     hig_workarea_add_section_title(t, &row, _("Details"));
 
     /* destination */
@@ -288,7 +287,6 @@ static GtkWidget *info_page_new(TrgTorrentPropsDialog * dialog)
     gtk_widget_set_halign(w, GTK_ALIGN_START);
     gtk_widget_set_valign(w, GTK_ALIGN_START);
 
-    hig_workarea_add_section_divider(t, &row);
     return t;
 }
 

--- a/src/trg-tree-view.c
+++ b/src/trg-tree-view.c
@@ -842,7 +842,6 @@ static void trg_tree_view_init(TrgTreeView * tv)
 {
     gtk_tree_view_set_rubber_banding(GTK_TREE_VIEW(tv), TRUE);
     gtk_tree_view_set_headers_clickable(GTK_TREE_VIEW(tv), TRUE);
-    gtk_tree_view_set_rules_hint(GTK_TREE_VIEW(tv), TRUE);
     gtk_tree_selection_set_mode(gtk_tree_view_get_selection
                                 (GTK_TREE_VIEW(tv)),
                                 GTK_SELECTION_MULTIPLE);

--- a/src/win32-mailslot.c
+++ b/src/win32-mailslot.c
@@ -138,7 +138,7 @@ static gpointer mailslot_recv_thread(gpointer data)
 
 void mailslot_start_background_listener(TrgMainWindow * win)
 {
-    g_thread_create(mailslot_recv_thread, win, FALSE, NULL);
+    g_thread_new(NULL, mailslot_recv_thread, win);
 }
 
 gboolean mailslot_send_message(gchar ** args)


### PR DESCRIPTION
Keeping track of them here as to not clutter the main repo

```
../src/trg-general-panel.c: In function ‘trg_general_panel_get_type_once’:
../src/trg-general-panel.c:47:1: warning: ‘gtk_table_get_type’ is deprecated [-Wdeprecated-declarations]
   47 | G_DEFINE_TYPE(TrgGeneralPanel, trg_general_panel, GTK_TYPE_TABLE)
      | ^~~~~~~~~~~~~
In file included from /usr/include/gtk-3.0/gtk/gtk.h:280,
                 from ../src/trg-general-panel.c:25:
/usr/include/gtk-3.0/gtk/deprecated/gtktable.h:117:12: note: declared here
  117 | GType      gtk_table_get_type         (void) G_GNUC_CONST;
      |            ^~~~~~~~~~~~~~~~~~
../src/trg-general-panel.c:283:5: warning: ‘gtk_table_attach’ is deprecated: Use 'GtkGrid' instead [-Wdeprecated-declarations]
  283 |     gtk_table_attach(GTK_TABLE(gp), alignment, startCol, startCol + 1, row,
      |     ^~~~~~~~~~~~~~~~
In file included from /usr/include/gtk-3.0/gtk/gtk.h:280,
                 from ../src/trg-general-panel.c:25:
/usr/include/gtk-3.0/gtk/deprecated/gtktable.h:127:12: note: declared here
  127 | void       gtk_table_attach           (GtkTable        *table,
      |            ^~~~~~~~~~~~~~~~
../src/trg-general-panel.c:283:5: warning: ‘gtk_table_get_type’ is deprecated [-Wdeprecated-declarations]
  283 |     gtk_table_attach(GTK_TABLE(gp), alignment, startCol, startCol + 1, row,
      |     ^~~~~~~~~~~~~~~~
In file included from /usr/include/gtk-3.0/gtk/gtk.h:280,
                 from ../src/trg-general-panel.c:25:
/usr/include/gtk-3.0/gtk/deprecated/gtktable.h:117:12: note: declared here
  117 | GType      gtk_table_get_type         (void) G_GNUC_CONST;
      |            ^~~~~~~~~~~~~~~~~~
../src/trg-general-panel.c:292:5: warning: ‘gtk_table_attach’ is deprecated: Use 'GtkGrid' instead [-Wdeprecated-declarations]
  292 |     gtk_table_attach(GTK_TABLE(gp), alignment, startCol + 1,
      |     ^~~~~~~~~~~~~~~~
In file included from /usr/include/gtk-3.0/gtk/gtk.h:280,
                 from ../src/trg-general-panel.c:25:
/usr/include/gtk-3.0/gtk/deprecated/gtktable.h:127:12: note: declared here
  127 | void       gtk_table_attach           (GtkTable        *table,
      |            ^~~~~~~~~~~~~~~~
../src/trg-general-panel.c:292:5: warning: ‘gtk_table_get_type’ is deprecated [-Wdeprecated-declarations]
  292 |     gtk_table_attach(GTK_TABLE(gp), alignment, startCol + 1,
      |     ^~~~~~~~~~~~~~~~
In file included from /usr/include/gtk-3.0/gtk/gtk.h:280,
                 from ../src/trg-general-panel.c:25:
/usr/include/gtk-3.0/gtk/deprecated/gtktable.h:117:12: note: declared here
  117 | GType      gtk_table_get_type         (void) G_GNUC_CONST;
      |            ^~~~~~~~~~~~~~~~~~
../src/trg-general-panel.c: In function ‘trg_general_panel_init’:
../src/trg-general-panel.c:368:9: warning: ‘gtk_table_set_col_spacing’ is deprecated: Use 'GtkGrid' instead [-Wdeprecated-declarations]
  368 |         gtk_table_set_col_spacing(GTK_TABLE(self), i,
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/gtk-3.0/gtk/gtk.h:280,
                 from ../src/trg-general-panel.c:25:
/usr/include/gtk-3.0/gtk/deprecated/gtktable.h:152:12: note: declared here
  152 | void       gtk_table_set_col_spacing  (GtkTable        *table,
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~
../src/trg-general-panel.c:368:9: warning: ‘gtk_table_get_type’ is deprecated [-Wdeprecated-declarations]
  368 |         gtk_table_set_col_spacing(GTK_TABLE(self), i,
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/gtk-3.0/gtk/gtk.h:280,
                 from ../src/trg-general-panel.c:25:
/usr/include/gtk-3.0/gtk/deprecated/gtktable.h:117:12: note: declared here
  117 | GType      gtk_table_get_type         (void) G_GNUC_CONST;
      |            ^~~~~~~~~~~~~~~~~~